### PR TITLE
Add sample data CSS styles via design/head/includes

### DIFF
--- a/db_preparation.sql
+++ b/db_preparation.sql
@@ -10,7 +10,26 @@ VALUES
     ('default', '0', 'catalog/recently_products/enabled_product_compare', '0', NULL),
     ('default', '0', 'catalog/recently_products/enabled_recently_viewed', '0', NULL),
     ('default', '0', 'catalog/frontend/enable_addtocart_in_product_listings', '0', NULL),
-    ('default', '0', 'design/head/demonotice', '1', NULL);
+    ('default', '0', 'design/head/demonotice', '1', NULL),
+    ('default', '0', 'design/head/includes', '<style>
+body.cms-home .main-container { padding-top: 0 }
+.promos { display: grid; gap: 20px; padding: 0; margin: 0 0 10px }
+@media (min-width: 771px) { .promos { grid-template-columns: repeat(3, 1fr) } }
+body .promos > li { list-style: none; margin: 0; user-select: none }
+.promos img { width: 100% }
+.promos a:hover { opacity: 0.8 }
+.cms-index-index .products-grid :is(.ratings, .actions),
+.cms-index-noroute .products-grid :is(.ratings, .actions) { display: none }
+.cms-index-index h2.subtitle { padding: 6px 0; text-align: center; color: var(--maho-color-primary); font-weight: 600; border-block: 1px solid var(--maho-color-border) }
+.cms-index-noroute h2.subtitle { display: none }
+.catblocks { display: grid; gap: 10px; padding-bottom: 20px }
+@media (min-width: 480px) { .catblocks { grid-template-columns: repeat(2, 1fr) } }
+@media (min-width: 771px) { .catblocks { grid-template-columns: repeat(4, 1fr) } }
+body .catblocks li { position: relative; list-style: none; margin: 0; border: 1px solid var(--maho-color-border) }
+.catblocks li:hover { border-color: var(--maho-color-primary) }
+.catblocks li img { width: 100%; display: block }
+.catblocks li a span { position: absolute; inset: auto 0 0; padding: 5px 10px; background: var(--maho-color-background-dark); color: var(--maho-color-background); font-weight: bold; text-transform: uppercase; text-align: center }
+</style>', NULL);
 
 INSERT INTO `permission_block` (block_name, is_allowed)
 VALUES


### PR DESCRIPTION
## Summary

- Move demo styles (promos, catblocks, homepage tweaks) from core Maho theme to sample data package
- CSS is now injected via `design/head/includes` config, making it self-contained with the sample data content it styles
- Modernized CSS: replaced floats with CSS Grid, removed vendor prefixes, reduced size ~70%

## Why

The sample data CSS in core Maho only styles content from this sample data package. Without sample data installed, the CSS does nothing. Moving it here keeps sample data self-contained.

## Related

This PR should be merged alongside the removal of the sample data CSS from core Maho.