### PR TITLE
Reduce hero slideshow height on homepage

### DIFF
--- a/db_config.sql
+++ b/db_config.sql
@@ -29,6 +29,9 @@ body .catblocks li { position: relative; list-style: none; margin: 0; border: 1p
 .catblocks li:hover { border-color: var(--maho-color-primary) }
 .catblocks li img { width: 100%; display: block }
 .catblocks li a span { position: absolute; inset: auto 0 0; padding: 5px 10px; background: var(--maho-color-background-dark); color: var(--maho-color-background); font-weight: bold; text-transform: uppercase; text-align: center }
+.slideshow { max-height: 400px }
+.slideshow ul li { width: 100%; height: 400px }
+.slideshow ul li a { display: block; width: 100%; height: 100% }
 </style>', NULL);
 
 INSERT INTO `permission_block` (block_name, is_allowed)


### PR DESCRIPTION
## Summary
- Limit slideshow height to 400px (from ~571px) for better above-fold content
- Add explicit dimensions to list items and anchor elements
- Promo banners and "New Products" section now visible without scrolling

## Related
- Works together with MahoCommerce/maho#505 which adds `object-fit: cover` support

## Test plan
- Visit the demo homepage
- Verify slideshow is ~400px tall
- Verify images fill full width with graceful vertical cropping
- Verify promo banners are visible above the fold